### PR TITLE
Blur query input after applying a quick filter

### DIFF
--- a/src/services/boardQueryApplicator.ts
+++ b/src/services/boardQueryApplicator.ts
@@ -114,6 +114,7 @@ export async function tryNativeBoardQuery(query: string): Promise<boolean> {
 
   await waitForUiTick();
   dispatchEnterKey(input);
+  input.blur();
 
   return true;
 }


### PR DESCRIPTION
Keeps focus from staying in Ring search when toggling filters off via the filter bar.